### PR TITLE
Add postinstall hook to run svelte-kit sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check"
+    "check": "svelte-kit sync && svelte-check",
+    "postinstall": "svelte-kit sync"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.2.2",


### PR DESCRIPTION
## Summary
- ensure `svelte-kit sync` runs after installing dependencies so SvelteKit runtime files are generated

## Testing
- npm install *(fails: registry returns HTTP 403 for @melt-ui/svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68e146393abc8328b0aa75b7dc32b6f2