### PR TITLE
Fix SvelteKit template compatibility issues

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    %svelte.head%
+    %sveltekit.head%
   </head>
   <body>
-    <div>%svelte.body%</div>
+    <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
   kit: {


### PR DESCRIPTION
## Summary
- update SvelteKit preprocessing import to use the vite plugin export
- replace deprecated %svelte placeholders in app.html with %sveltekit variants

## Testing
- npm run build *(fails: pre-existing A11y warning and missing createFileUpload export in @melt-ui/svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68e15296fea08328b503bbd5ffc1d01a