### PR TITLE
Fix radio group accessibility and clean combobox styles

### DIFF
--- a/src/routes/melt-components/+page.svelte
+++ b/src/routes/melt-components/+page.svelte
@@ -280,7 +280,12 @@
   <div class="radio" use:radioGroup.root>
     {#each radioGroup.items as option}
       <label class="radio-option">
-        <span class="radio-control" use:radioGroup.item={{ value: option.value }}></span>
+        <input
+          class="sr-only"
+          type="radio"
+          use:radioGroup.item={{ value: option.value }}
+        />
+        <span class="radio-control" aria-hidden="true"></span>
         {option.label}
       </label>
     {/each}
@@ -557,8 +562,7 @@
     cursor: pointer;
   }
 
-  .combobox-item:hover,
-  .combobox-item[aria-selected='true'] {
+  .combobox-item:hover {
     background: rgba(37, 99, 235, 0.1);
   }
 
@@ -630,6 +634,18 @@
   .progress-bar {
     height: 100%;
     background: linear-gradient(135deg, #2563eb, #22d3ee);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .radio {


### PR DESCRIPTION
## Summary
- associate each radio label with an actual input element for better accessibility while keeping the custom control visuals
- add a reusable sr-only utility class for visually hidden inputs
- remove an unused combobox aria-selected selector to clear svelte-check warnings

## Testing
- npm run check *(fails: @sveltejs/kit/vite does not provide vitePreprocess export in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e152dc24c88328a48af8d33039830e