### PR TITLE
Fix radio group accessibility and clean combobox styles

### DIFF
--- a/src/routes/melt-components/+page.svelte
+++ b/src/routes/melt-components/+page.svelte
@@ -279,10 +279,14 @@
   </header>
   <div class="radio" use:radioGroup.root>
     {#each radioGroup.items as option}
-      <label class="radio-option">
-        <span class="radio-control" use:radioGroup.item={{ value: option.value }}></span>
+      <button
+        class="radio-option"
+        type="button"
+        use:radioGroup.item={{ value: option.value }}
+      >
+        <span class="radio-control" aria-hidden="true"></span>
         {option.label}
-      </label>
+      </button>
     {/each}
   </div>
 </section>
@@ -558,7 +562,7 @@
   }
 
   .combobox-item:hover,
-  .combobox-item[aria-selected='true'] {
+  :global(.combobox-item[data-selected]) {
     background: rgba(37, 99, 235, 0.1);
   }
 
@@ -641,9 +645,19 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+    border: none;
     background: rgba(15, 23, 42, 0.05);
     padding: 0.5rem 0.75rem;
     border-radius: 0.75rem;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    outline: none;
+  }
+
+  .radio-option:focus-visible {
+    outline: 2px solid rgba(37, 99, 235, 0.6);
+    outline-offset: 2px;
   }
 
   .radio-control {
@@ -651,6 +665,11 @@
     height: 1rem;
     border-radius: 9999px;
     border: 2px solid rgba(37, 99, 235, 0.4);
+  }
+
+  :global(.radio-option[data-state='checked'] .radio-control) {
+    background: #2563eb;
+    border-color: #2563eb;
   }
 
   .select {


### PR DESCRIPTION
## Summary
- replace the radio group label with a button element so each option is an actual control and improve its focus and checked styling
- update the combobox selected item styling to rely on the data-selected attribute via a global selector to keep the highlight without compiler warnings

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e1542ecff48328891805f59917863a