### PR TITLE
Handle SvelteKit params props

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,3 +1,8 @@
+<script>
+  export let params;
+  $: void params;
+</script>
+
 <svelte:head>
   <title>Tutorial - Svelte & Melt UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,9 @@
+<script>
+  export let params;
+  $: void params;
+
+</script>
+
 <section class="hero">
   <h1>Welcome to the Svelte + Melt UI tutorial project</h1>
   <p>

--- a/src/routes/melt-components/+layout.svelte
+++ b/src/routes/melt-components/+layout.svelte
@@ -2,6 +2,9 @@
   import { page } from '$app/stores';
   import { componentPages } from './components';
 
+  export let params;
+  $: void params;
+
   const linkFor = (slug) => (slug ? `/melt-components/${slug}` : '/melt-components');
 </script>
 

--- a/src/routes/melt-components/+page.svelte
+++ b/src/routes/melt-components/+page.svelte
@@ -1,5 +1,9 @@
 <script>
   import { componentPages } from './components';
+
+  export let params;
+  $: void params;
+
   const componentLinks = componentPages.filter((item) => item.slug !== '');
 </script>
 

--- a/src/routes/melt-components/accordion/+page.svelte
+++ b/src/routes/melt-components/accordion/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createAccordion } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, item, trigger, content }
   } = createAccordion({

--- a/src/routes/melt-components/avatar/+page.svelte
+++ b/src/routes/melt-components/avatar/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createAvatar } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, image, fallback }
   } = createAvatar({

--- a/src/routes/melt-components/collapsible/+page.svelte
+++ b/src/routes/melt-components/collapsible/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createCollapsible } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, trigger, content }
   } = createCollapsible({ defaultOpen: true });

--- a/src/routes/melt-components/combobox/+page.svelte
+++ b/src/routes/melt-components/combobox/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createCombobox } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { input, menu, option }
   } = createCombobox({

--- a/src/routes/melt-components/pin-input/+page.svelte
+++ b/src/routes/melt-components/pin-input/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createPinInput } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, input }
   } = createPinInput({

--- a/src/routes/melt-components/popover/+page.svelte
+++ b/src/routes/melt-components/popover/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createPopover } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { trigger, content }
   } = createPopover();

--- a/src/routes/melt-components/progress/+page.svelte
+++ b/src/routes/melt-components/progress/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createProgress } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root }
   } = createProgress({ value: 45, max: 100 });

--- a/src/routes/melt-components/radio-group/+page.svelte
+++ b/src/routes/melt-components/radio-group/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createRadioGroup } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, item }
   } = createRadioGroup({ defaultValue: 'full' });

--- a/src/routes/melt-components/select/+page.svelte
+++ b/src/routes/melt-components/select/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createSelect } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { trigger, menu, option },
     states: { selectedLabel, open }

--- a/src/routes/melt-components/slider/+page.svelte
+++ b/src/routes/melt-components/slider/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createSlider } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, range, thumb },
     states: { value }

--- a/src/routes/melt-components/spatial-menu/+page.svelte
+++ b/src/routes/melt-components/spatial-menu/+page.svelte
@@ -1,4 +1,7 @@
 <script>
+  export let params;
+  $: void params;
+
   const actions = [
     { id: 'new', label: 'New File', description: 'Create a document' },
     { id: 'open', label: 'Open…', description: 'Browse recent files' },

--- a/src/routes/melt-components/tabs/+page.svelte
+++ b/src/routes/melt-components/tabs/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createTabs } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root, list, trigger, content }
   } = createTabs({ defaultValue: 'overview' });

--- a/src/routes/melt-components/toaster/+page.svelte
+++ b/src/routes/melt-components/toaster/+page.svelte
@@ -2,6 +2,9 @@
   import { onMount } from 'svelte';
   import { createToaster } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { content, title, description, close },
     helpers: { addToast },

--- a/src/routes/melt-components/toggle/+page.svelte
+++ b/src/routes/melt-components/toggle/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createToggle } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { root },
     states: { pressed }

--- a/src/routes/melt-components/tooltip/+page.svelte
+++ b/src/routes/melt-components/tooltip/+page.svelte
@@ -1,6 +1,9 @@
 <script>
   import { createTooltip } from '@melt-ui/svelte';
 
+  export let params;
+  $: void params;
+
   const {
     elements: { trigger, content, arrow }
   } = createTooltip({


### PR DESCRIPTION
## Summary
- export the SvelteKit `params` prop in the root layout and page so the router no longer warns about unknown props
- update each Melt UI example page and the gallery layout to accept route params while marking them as intentionally unused

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e22d40fc2c8328a153402c436f641a